### PR TITLE
Bug for SmallStraight points

### DIFF
--- a/adapted/yahtzee_rules.py
+++ b/adapted/yahtzee_rules.py
@@ -83,7 +83,7 @@ class SmallStraight(Straight):
         return "Small straight"
 
     def points(self, hand: Hand):
-        l = sorted(hand.get_hand())
+        l = sorted(set(hand.get_hand()))
         if len(l) == 4 and self.is_straight(l):
             return 30
         elif len(l) == 5 and (self.is_straight(l[1:]) or self.is_straight(l[:-1])):


### PR DESCRIPTION
The SmallStraight rule would not return the correct amount of points for a hand like [1,2,3,3,4].